### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For information about how it works, read the [whitepaper](monophonic_audio_to_mi
 
 ### Installation from pip
 
-`pip install sound_to_midi`
+`pip install sound-to-midi`
 
 ### Installation from Github repo
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ For information about how it works, read the [whitepaper](monophonic_audio_to_mi
     import sys
     import librosa
 
-    from audio_to_midi.monophonic import wave_to_midi
+    from sound_to_midi.monophonic import wave_to_midi
 
     print("Starting...")
     file_in = sys.argv[1]
     file_out = sys.argv[2]
     y, sr = librosa.load(file_in, sr=None)
     print("Audio file loaded!")
-    midi = wave_to_midi(y, sr=sr)
+    midi = wave_to_midi(y, srate=sr)
     print("Conversion finished!")
     with open (file_out, 'wb') as f:
         midi.writeFile(f)


### PR DESCRIPTION
Execute ”pip install sound_to_midi“ will failed, and i found the correct situation is what to execute "pip install sound-to-midi"